### PR TITLE
Fixed broken Link in installation.md

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -24,7 +24,7 @@ The Elkarbackup installation has been tested on the next systems:
 
   </details>
 
-  [After the installation](/getting-started.md)
+  [After the installation](/docs/getting-started.md)
 
   ***
   

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -24,7 +24,7 @@ The Elkarbackup installation has been tested on the next systems:
 
   </details>
 
-  [After the installation](/get-started.html)
+  [After the installation](/getting-started.md)
 
   ***
   


### PR DESCRIPTION
/docs/installation.md pointed to "/get-starting.html". It should be "/docs/getting-started.md".
This PR fixes this.