### PR TITLE
Correcting wrong indentation for the volumes-level. This is wrong in …

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -160,7 +160,7 @@ services:
     environment:
       SYMFONY__DATABASE__PASSWORD: "your-password-here"
       EB_CRON: "enabled"
-      volumes:
+    volumes:
       - backups:/app/backups
       - uploads:/app/uploads
       - sshkeys:/app/.ssh


### PR DESCRIPTION
The docker-compose example has a wrong indentation in the docs and at dockerhub. This results in the following error:

```
# docker-compose up
ERROR: The Compose file './docker-compose.yml' is invalid because:
services.elkarbackup.environment.volumes contains ["backups:/app/backups", "uploads:/app/uploads", "sshkeys:/app/.ssh"], which is an invalid type, it should be a string, number, or a null`
```